### PR TITLE
Adding nvr lookup to results

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,19 +19,19 @@ properties(
     parameters(
       [
         [$class: 'ValidatingStringParameterDefinition',
-         defaultValue: 'x86_64',
+         defaultValue: 'x86_64,ppc64le',
          description: 'A comma separated list of architectures to run the test on. Valid values include [x86_64, ppc64le, aarch64, s390x].',
          failedValidationMessage: 'Invalid architecture. Valid values are [x86_64, ppc64le, aarch64, s390x].',
          name: 'ARCHES',
          regex: '^(?:x86_64|ppc64le|aarch64|s390x)(?:,\\s*(?:x86_64|ppc64le|aarch64|s390x))*$'
         ],
         string(
-          defaultValue: 'https://github.com/jaypoulz/multiarch-ci-libraries',
+          defaultValue: 'https://github.com/redhat-multiarch-qe/multiarch-ci-libraries',
           description: 'Repo for shared libraries.',
           name: 'LIBRARIES_REPO'
         ),
         string(
-          defaultValue: 'dev-v1.2.2',
+          defaultValue: 'v1.2.2',
           description: 'Git reference to the branch or tag of shared libraries.',
           name: 'LIBRARIES_REF'
         ),
@@ -90,7 +90,6 @@ library(
 def errorMessages = ''
 def config = MAQEAPI.v1.getProvisioningConfig(this)
 config.installRhpkg = true
-//config.mode = 'JNLP'
 
 // Get build information
 Map message = [:]
@@ -211,7 +210,7 @@ MAQEAPI.v1.runTest(
     if (errorMessages) emailBody += "\nErrors: " + errorMessages
 
     emailext(
-      subject: "${env.JOB_NAME} (#${currentBuild.number}) - ${nvr ? nvr + ' - ': ''}${currentBuild.currentResult}",
+      subject: "${nvr ? nvr + ' - ': ''}${currentBuild.currentResult} - ${env.JOB_NAME} (#${currentBuild.number})",
       body: emailBody,
       from: 'multiarch-qe-jenkins',
       replyTo: 'multiarch-qe',

--- a/tests/scripts/example-test/test.sh
+++ b/tests/scripts/example-test/test.sh
@@ -1,1 +1,0 @@
-echo "This is a shell script test"

--- a/tests/scripts/example-test2/test.sh
+++ b/tests/scripts/example-test2/test.sh
@@ -1,1 +1,0 @@
-echo "This test should run too"

--- a/tests/scripts/rhel-system-roles/test.sh
+++ b/tests/scripts/rhel-system-roles/test.sh
@@ -2,19 +2,14 @@
 #
 # Attempts to clone down the test package and run it
 
-# Ensure Ansible gets installed from task repo
-sudo yum remove ansible -y
-sudo yum install ansible -y --disablerepo epel
-sudo yum-config-manager --save --setopt epel.exclude=ansible*
-
 cd "$(dirname ${BASH_SOURCE[0]})"
 workdir=$(pwd)
 rhpkg --verbose --user=jenkins clone tests/rhel-system-roles
 cd rhel-system-roles
 git checkout CoreOS-rhel-system-roles-Sanity-Upstream-testsuite-multiarch-ci-1_1-1
 cd Sanity/Upstream-testsuite-multiarch-ci
-output_dir="$workdir/artifacts/rhel-system-roles"
-output_file="$output_dir/$(arch).txt"
+output_dir="$workdir/artifacts/rhel-system-roles/results"
+output_file="$output_dir/$(arch)-test-output.txt"
 mkdir -p $output_dir
 sudo make &> $output_file run
 grep "OVERALL RESULT" $output_file | grep "PASS"


### PR DESCRIPTION
Removed nvr if it doesn't exist

Removed sudo

Fixed bad substitution

Added more prereqs for install

Removing the global disable since it prevents ansible from installing properly.

Don't run these tests unless the target is RHEL7

Encountered an issue where you don't know which OS to install until you install brew

Updated Ansible Engine test to lookup build info before attempting to provision hosts

Adding new UUID

Fixing closure syntax

Escaping $

Fixed distro ternary

Attempting to parse message within node step

Initializing message to map

Cleaning up script

Removing the newline from brew lookup

Underscores for constants/param strings

Pushing the created target hosts

Debugging why arch is coming up as a string ref

Converted debug big into a string

Updating to runTest method so TargetHosts will be interpretted correctly

Disabling JNLP mode for RHEL-8 support

Updating to dev libs

Cleaned up dead tests and remove epel disable

Limited scope since machines are down

Added inventory file override for ansible_python_interpret on rhel-8 hosts

Fixed variable name

Removed debugging log and renamed output